### PR TITLE
Improve ConvertFrom-Timestamp

### DIFF
--- a/Source/Private/ConvertFrom-Timestamp.ps1
+++ b/Source/Private/ConvertFrom-Timestamp.ps1
@@ -7,7 +7,7 @@ function ConvertFrom-Timestamp {
     )
     
     process {
-        (Get-Date '1970-01-01').AddMilliseconds($Timestamp)
+        [System.DateTimeOffset]::UnixEpoch.AddSeconds($Timestamp)
     }
   
 }


### PR DESCRIPTION
Uses DateTimeOffset instead of DateTime
 - This adds better support for timezones

Also uses static property UnixEpoch